### PR TITLE
Adapter feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,16 @@ To enable or disable the tracking of Airship CustomEvent objects, use the should
 
 ```java
     // To enable CustomEvent tracking for place exits
-    AirshipAdapter.shared(UAirship.getApplicationContext()).setShouldTrackCustomExitEvent(true);
+    AirshipAdapter.shared(context).setShouldTrackCustomExitEvent(true);
 
     // To disable CustomEvent tracking for place exits
-    AirshipAdapter.shared(UAirship.getApplicationContext()).setShouldTrackCustomExitEvent(false);
+    AirshipAdapter.shared(context).setShouldTrackCustomExitEvent(false);
     
     // To enable CustomEvent tracking for place entries
-    AirshipAdapter.shared(UAirship.getApplicationContext()).setShouldTrackCustomEntryEvent(true);
+    AirshipAdapter.shared(context).setShouldTrackCustomEntryEvent(true);
     
     // To disable CustomEvent tracking for place entries
-    AirshipAdapter.shared(UAirship.getApplicationContext()).setShouldTrackCustomEntryEvent(false);
+    AirshipAdapter.shared(context).setShouldTrackCustomEntryEvent(false);
 ```
 
 ## Stopping the adapter

--- a/airship-adapter/src/main/java/com/gimbal/airship/AirshipReadyReceiver.java
+++ b/airship-adapter/src/main/java/com/gimbal/airship/AirshipReadyReceiver.java
@@ -8,6 +8,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import com.urbanairship.UAirship;
+
 /**
  * Broadcast receiver for Airship Ready events.
  */
@@ -15,6 +17,11 @@ public class AirshipReadyReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, Intent intent) {
-        AirshipAdapter.shared(context).unloadQueuedEvents();
+        // We have a crash report from a customer that indicates this is somehow
+        // called before Airship is ready. We believe its a stale intent being
+        // delivered late. Check for ready to be safe.
+        if (UAirship.isFlying() || UAirship.isTakingOff()) {
+            AirshipAdapter.shared(context).onAirshipReady();
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         adapterVersion = '1.0.0'
 
         // Dependencies
-        airshipVersion = '16.5.0'
+        airshipVersion = '16.7.5'
         gimbalVersion = '4.8.0'
 
         // Android SDK versions


### PR DESCRIPTION
Changes:
- Update readme to point to the context instead of Airships context.  It should be fine either way but the app should have its own context.
- Update to latest Airship SDK
- Use new APIs in the SDK for requesting permission instead of deprecated ones. It's currently marked as restricted but we will remove that in the next SDK so you can remove the suppress annotation.
- The cached visit code potentially had potential crash depending on the thread Gimbal uses to deliver updates. If everything was on the main thread it would be fine, but if not, it's possible you could get a ConcurrentModificationException. The new changes iterates over a copy to prevent that and syncs on it to avoid trying to insert a value while Airship becomes available.
- Made it possible for the adapter to be started before Airship is ready.  I added a check for Airship being ready in updateDeviceAttributes and added a listener for channel creates once in onAirshipReady.

